### PR TITLE
Add `.ipynb_checkpoints` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ output
 scrap.txt
 temp-plot.html
 tmp
+.ipynb_checkpoints


### PR DESCRIPTION
The checkpoints are similar files as the original notebooks but are only updated on a manual save. The original notebooks are updated with autosave and when manually saving. TL:DR `.ipynb_checkpoints` shouldn't;t be committed and thus should be added to `.gitignore`.

Also from [Jupyter Notebooks official documentation](https://jupyter-tutorial.readthedocs.io/en/stable/productive/git/best-practices.html):

> If no .gitignore file is present in your project, you should create one and at least -exclude .ipynb_checkpoints and */.ipynb_checkpoints/*.