### PR TITLE
Dav vrat cutmix

### DIFF
--- a/destriping/augmentation_pipeline/pipeline.py
+++ b/destriping/augmentation_pipeline/pipeline.py
@@ -28,7 +28,7 @@ def main(args):
     for i in range(aug.__len__()):
         output_path = f"{output_directory}/{i + 1}.png"
         aug.plot(i, save_to=output_path)
-    print(f"Saved augmented dataset to {output_path}")
+    print(f"Saved augmented dataset to {output_directory}")
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Generate and save augmented images from a hypercube.")

--- a/destriping/augmentation_pipeline/pipeline.py
+++ b/destriping/augmentation_pipeline/pipeline.py
@@ -1,9 +1,11 @@
 import sys
+import os
+import shutil
 
 sys.path.append("..")
 from data.loader import HyperSpectralCube, AugmentedDataset
-from augmentation_pipeline.cutmix_mixup import generate_augmented_images, visualize_augmentations, cutmix_augmentation, mixup_augmentation
-import random
+# from augmentation_pipeline.cutmix_mixup import generate_augmented_images, visualize_augmentations, cutmix_augmentation, mixup_augmentation
+# import random
 import argparse
 
 def main(args):
@@ -17,8 +19,14 @@ def main(args):
     )
 
     output_directory = args.output_directory
+
+    #remove existing output directory and create a new one
+    if os.path.exists(output_directory):
+        shutil.rmtree(output_directory)
+    os.makedirs(output_directory)
+    
     for i in range(aug.__len__()):
-        output_path = f"{output_directory}/{i}.png"
+        output_path = f"{output_directory}/{i + 1}.png"
         aug.plot(i, save_to=output_path)
     print(f"Saved augmented dataset to {output_path}")
 
@@ -27,9 +35,9 @@ if __name__ == "__main__":
     parser.add_argument("--hypercube_path", type=str, help="Path to the hypercube file.")
     parser.add_argument("--hyperspectral_label", type=str, default="paviaU", help="The label of the hyperspectral cube in the .mat file.")
     parser.add_argument("--alpha", type=float, default=0.5, help="Alpha value for AugmentedDataset.")
-    parser.add_argument("--size", type=int, default=32, help="Size parameter for AugmentedDataset.")
-    parser.add_argument("--mixup_images", type=int, default=100, help="Number of mixup images for AugmentedDataset.")
-    parser.add_argument("--cutmix_images", type=int, default=100, help="Number of cutmix images for AugmentedDataset.")
+    parser.add_argument("--size", type=int, default=128, help="Size parameter for AugmentedDataset.")
+    parser.add_argument("--mixup_images", type=int, default=15, help="Number of mixup images for AugmentedDataset.")
+    parser.add_argument("--cutmix_images", type=int, default=15, help="Number of cutmix images for AugmentedDataset.")
     parser.add_argument("--output_directory", type=str, default="output_images", help="Directory to save augmented images.")
 
     args = parser.parse_args()

--- a/destriping/data/loader.py
+++ b/destriping/data/loader.py
@@ -15,14 +15,15 @@ class AugmentedDataset(Dataset):
         self, dataset, alpha=0.5, size=16, mixup_images=None, cutmix_images=None
     ):
         augmented_images_cutmix = generate_augmented_images(
-            dataset, num_samples=cutmix_images, augmentation_type="cutmix"
+            dataset, num_samples=cutmix_images, augmentation_type="cutmix", size = size
         )
         augmented_images_mixup = generate_augmented_images(
-            dataset, num_samples=mixup_images, augmentation_type="mixup"
+            dataset, num_samples=mixup_images, augmentation_type="mixup", alpha = alpha
         )
-        original_images = [dataset[i] for i in range(dataset.__len__())]
+        # original_images = [dataset[i] for i in range(dataset.__len__())]
         stacked_tensor = torch.stack(
-            original_images + augmented_images_cutmix + augmented_images_mixup
+            augmented_images_cutmix + augmented_images_mixup
+            # original_images + augmented_images_cutmix + augmented_images_mixup
         )
         self.images = stacked_tensor
         self.cube = self.images.numpy()
@@ -38,7 +39,7 @@ class AugmentedDataset(Dataset):
         plt.imshow(self.images[index])
         if save_to:
             plt.savefig(save_to)
-        plt.show()
+        # plt.show()
         return
 
 

--- a/destriping/data/loader.py
+++ b/destriping/data/loader.py
@@ -20,7 +20,7 @@ class AugmentedDataset(Dataset):
         augmented_images_mixup = generate_augmented_images(
             dataset, num_samples=mixup_images, augmentation_type="mixup", alpha = alpha
         )
-        # original_images = [dataset[i] for i in range(dataset.__len__())]
+        original_images = [dataset[i] for i in range(dataset.__len__())]
         stacked_tensor = torch.stack(
             augmented_images_cutmix + augmented_images_mixup
             # original_images + augmented_images_cutmix + augmented_images_mixup

--- a/destriping/data/loader.py
+++ b/destriping/data/loader.py
@@ -23,7 +23,7 @@ class AugmentedDataset(Dataset):
         original_images = [dataset[i] for i in range(dataset.__len__())]
         stacked_tensor = torch.stack(
             augmented_images_cutmix + augmented_images_mixup
-            # original_images + augmented_images_cutmix + augmented_images_mixup
+            original_images + augmented_images_cutmix + augmented_images_mixup
         )
         self.images = stacked_tensor
         self.cube = self.images.numpy()

--- a/destriping/data/loader.py
+++ b/destriping/data/loader.py
@@ -22,7 +22,7 @@ class AugmentedDataset(Dataset):
         )
         original_images = [dataset[i] for i in range(dataset.__len__())]
         stacked_tensor = torch.stack(
-            augmented_images_cutmix + augmented_images_mixup
+            # augmented_images_cutmix + augmented_images_mixup
             original_images + augmented_images_cutmix + augmented_images_mixup
         )
         self.images = stacked_tensor


### PR DESCRIPTION
- Improved output generation by resetting the output directory on every run
- Increased default size, and decreased default number of cutmix and mixup images in pipeline.py
- Removed unnecessary imports in pipeline.py
- Disabled plt.show() in AugmentedDataset
- Removed original images from the augmented cube in AugmentedDataset